### PR TITLE
Add tdo_driven to top level.

### DIFF
--- a/src/main/scala/craft/Craft2DSP.scala
+++ b/src/main/scala/craft/Craft2DSP.scala
@@ -84,8 +84,8 @@ trait PeripheryCraft2DSPModule extends HasPeripheryParameters {
     jtag.TCK      := io.tclk
     jtag.TMS      := io.tms
     jtag.TDI      := io.tdi
-    io.tdo   := jtag.TDO.data
-    // jtag.TDO.driven?
+    io.tdo        := jtag.TDO.data
+    io.tdo_driven := jtag.TDO.driven
     // TRST doesn't exist yet
   })
 

--- a/src/main/scala/craft/JTAG.scala
+++ b/src/main/scala/craft/JTAG.scala
@@ -6,11 +6,12 @@ import cde._
 import chisel3.core.ExplicitCompileOptions.NotStrict
 
 trait JTAGTopLevelIO {
-  val trst = Input(Bool())
-  val tms  = Input(Bool())
-  val tdi  = Input(Bool())
-  val tdo  = Output(Bool())
-  val tclk = Input(Bool())
+  val trst       = Input(Bool())
+  val tms        = Input(Bool())
+  val tdi        = Input(Bool())
+  val tdo        = Output(Bool())
+  val tclk       = Input(Bool())
+  val tdo_driven = Output(Bool())
 }
 
 

--- a/src/main/scala/craft/TestHarness.scala
+++ b/src/main/scala/craft/TestHarness.scala
@@ -70,6 +70,7 @@ class CraftP1Core(implicit val p: Parameters) extends Module with RealAnalogAnno
   craft.io.tms  := io.tms
   craft.io.tdi  := io.tdi
   io.tdo        := craft.io.tdo
+  io.tdo_driven := craft.io.tdo_driven
   craft.io.tclk := io.tclk
 
   // CLKRX


### PR DESCRIPTION
Currently fails because pad frame needs to be updated